### PR TITLE
Fix infinite recursion in HashMap on Python3

### DIFF
--- a/disco/util/hashmap.py
+++ b/disco/util/hashmap.py
@@ -11,7 +11,7 @@ class HashMap(dict):
         return iter(self)
 
     def items(self):
-        return six.iteritems(self)
+        return six.iteritems(super(HashMap, self))
 
     def find(self, predicate):
         if not callable(predicate):


### PR DESCRIPTION
Since `six.iteritems()` on Python3 internally calls `items()` again, supplying it with the superclass object instead avoids the recursion issue.

One more thing, the `data` attribute in [StorageHashMap](https://github.com/b1naryth1ef/disco/blob/master/disco/bot/storage.py#L11) isn't being used, because HashMap itself doesn't subclass UserDict anymore. Would it be alright to just make StorageHashMap a subclass of both UserDict and HashMap to fix this while maintaining the utility methods of HashMap?