### PR TITLE
Fix overwrites order in Channel.get_permissions

### DIFF
--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -159,12 +159,18 @@ class Channel(SlottedModel, Permissible):
         member = self.guild.get_member(user)
         base = self.guild.get_permissions(member)
 
-        for ow in six.itervalues(self.overwrites):
-            if ow.id != user.id and ow.id not in member.roles:
-                continue
-
-            base -= ow.deny
-            base += ow.allow
+        ow_everyone = self.overwrites.get(self.guild_id)
+        if ow_everyone:
+            base += ow_everyone.compiled
+        
+        for role_id in member.roles:
+            ow_role = self.overwrites.get(role_id)
+            if ow_role:
+                base += ow_role.compiled
+        
+        ow_member = self.overwrites.get(member.user.id)
+        if ow_member:
+            base += ow_member.compiled
 
         return base
 

--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -162,12 +162,12 @@ class Channel(SlottedModel, Permissible):
         ow_everyone = self.overwrites.get(self.guild_id)
         if ow_everyone:
             base += ow_everyone.compiled
-        
+
         for role_id in member.roles:
             ow_role = self.overwrites.get(role_id)
             if ow_role:
                 base += ow_role.compiled
-        
+
         ow_member = self.overwrites.get(member.user.id)
         if ow_member:
             base += ow_member.compiled


### PR DESCRIPTION
If i'm not mistaken, it is important to respect the order when computing permissions of a user in a channel.

P.S This hasn't been tested but should work just fine