### PR TITLE
Fix shared_config initialization typo

### DIFF
--- a/disco/bot/bot.py
+++ b/disco/bot/bot.py
@@ -506,7 +506,7 @@ class Bot(LoggingClass):
 
         data = {}
         if self.config.shared_config:
-            data.update(self.config.shared)
+            data.update(self.config.shared_config)
 
         if name in self.config.plugin_config:
             data.update(self.config.plugin_config[name])


### PR DESCRIPTION
You'd have to put your variables in a `shared` dict and set `shared_config` to something truthy before, which I don't think was the intent 👍 