### PR TITLE
Fix docs anchors rendering

### DIFF
--- a/docs/book.json
+++ b/docs/book.json
@@ -1,6 +1,6 @@
 {
   "title": "Disco",
-  "plugins": ["prism", "-highlight", "hints"],
+  "plugins": ["prism", "-highlight", "hints", "anchorjs"],
 	"pluginsConfig": {
 			"anchorjs": {
 					"placement": "left",


### PR DESCRIPTION
It would seem that anchors have not been rendering in documentation because `anchorjs` isn't actually installed at build time. This should fix that:

![image](https://user-images.githubusercontent.com/6119032/43034602-734df322-8cad-11e8-8b5e-fa70c88fb9d8.png)
