### PR TITLE
Typo Fixes

### DIFF
--- a/disco/api/client.py
+++ b/disco/api/client.py
@@ -48,8 +48,8 @@ class APIClient(LoggingClass):
     is the only path to the API used within models/other interfaces, and it's
     the recommended path for all third-party users/implementations.
 
-    Args
-    ----
+    Parameters
+    ----------
     token : str
         The Discord authentication token (without prefixes) to be used for all
         HTTP requests.

--- a/disco/api/http.py
+++ b/disco/api/http.py
@@ -239,7 +239,7 @@ class HTTPClient(LoggingClass):
             to create the requestable route. The HTTPClient uses this to track
             rate limits as well.
         kwargs : dict
-            Keyword arguments that will be passed along to the requests library
+            Keyword arguments that will be passed along to the requests library.
 
         Raises
         ------
@@ -250,7 +250,7 @@ class HTTPClient(LoggingClass):
         Returns
         -------
         :class:`requests.Response`
-            The response object for the request
+            The response object for the request.
         """
         args = args or {}
         retry = kwargs.pop('retry_number', 0)
@@ -313,7 +313,7 @@ class HTTPClient(LoggingClass):
         client suspects is transient. Will always return a value between 500 and
         5000 milliseconds.
 
-        :returns: a random backoff in milliseconds
+        :returns: a random backoff in milliseconds.
         :rtype: float
         """
         return random.randint(500, 5000) / 1000.0

--- a/disco/api/ratelimit.py
+++ b/disco/api/ratelimit.py
@@ -26,7 +26,7 @@ class RouteState(LoggingClass):
         The number of remaining requests to the route before the rate limit will
         be hit, triggering a 429 response.
     reset_time : int
-        A unix epoch timestamp (in seconds) after which this rate limit is reset
+        A UNIX epoch timestamp (in seconds) after which this rate limit is reset.
     event : :class:`gevent.event.Event`
         An event that is used to block all requests while a route is in the
         cooldown stage.
@@ -45,7 +45,7 @@ class RouteState(LoggingClass):
     @property
     def chilled(self):
         """
-        Whether this route is currently being cooldown (aka waiting until reset_time).
+        Whether this route is currently being cooled-down (aka waiting until reset_time).
         """
         return self.event is not None
 
@@ -63,8 +63,8 @@ class RouteState(LoggingClass):
 
     def update(self, response):
         """
-        Updates this route with a given Requests response object. Its expected
-        the response has the required headers, however in the case it doesn't
+        Updates this route with a given Requests response object. It's expected
+        the response has the required headers, however in the case that it doesn't
         this function has no effect.
         """
         if 'X-RateLimit-Remaining' not in response.headers:
@@ -108,7 +108,7 @@ class RouteState(LoggingClass):
 
 class RateLimiter(LoggingClass):
     """
-    A in-memory store of ratelimit states for all routes we've ever called.
+    An in-memory store of ratelimit states for all routes we've ever called.
 
     Attributes
     ----------
@@ -124,7 +124,7 @@ class RateLimiter(LoggingClass):
         Checks whether a given route can be called. This function will return
         immediately if no rate-limit cooldown is being imposed for the given
         route, or will wait indefinitely until the route is finished being
-        cooled down. This function should be called before making a request to
+        cooled-down. This function should be called before making a request to
         the specified route.
 
         Parameters

--- a/disco/bot/bot.py
+++ b/disco/bot/bot.py
@@ -27,7 +27,7 @@ class BotConfig(Config):
     Attributes
     ----------
     levels : dict(snowflake, str)
-        Mapping of user IDs/role IDs to :class:`disco.bot.commands.CommandLevesls`
+        Mapping of user IDs/role IDs to :class:`disco.bot.commands.CommandLevels`
         which is used for the default commands_level_getter.
     plugins : list[string]
         List of plugin modules to load.
@@ -41,15 +41,15 @@ class BotConfig(Config):
         A dictionary describing what mention types can be considered a mention
         of the bot when using :attr:`commands_require_mention`. This dictionary
         can contain the following keys: `here`, `everyone`, `role`, `user`. When
-        a keys value is set to true, the mention type will be considered for
+        a key's value is set to true, the mention type will be considered for
         command parsing.
     commands_prefix : str
         A string prefix that is required for a message to be considered for
         command parsing.
     commands_allow_edit : bool
-        If true, the bot will reparse an edited message if it was the last sent
+        If true, the bot will re-parse an edited message if it was the last sent
         message in a channel, and did not previously trigger a command. This is
-        helpful for allowing edits to typod commands.
+        helpful for allowing edits to typed commands.
     commands_level_getter : function
         If set, a function which when given a GuildMember or User, returns the
         relevant :class:`disco.bot.commands.CommandLevels`.
@@ -70,9 +70,9 @@ class BotConfig(Config):
         Whether to enable the built-in Flask server which allows plugins to handle
         and route HTTP requests.
     http_host : str
-        The host string for the HTTP Flask server (if enabled)
+        The host string for the HTTP Flask server (if enabled).
     http_port : int
-        The port for the HTTP Flask server (if enabled)
+        The port for the HTTP Flask server (if enabled).
     """
     levels = {}
     plugins = []
@@ -109,7 +109,7 @@ class BotConfig(Config):
 class Bot(LoggingClass):
     """
     Disco's implementation of a simple but extendable Discord bot. Bots consist
-    of a set of plugins, and a Disco client.
+    of a set of plugins, and a Disco Client.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ class Bot(LoggingClass):
     config : `BotConfig`
         The bot configuration instance for this bot.
     plugins : dict(str, :class:`disco.bot.plugin.Plugin`)
-        Any plugins this bot has loaded
+        Any plugins this bot has loaded.
     """
     def __init__(self, client, config=None):
         self.client = client
@@ -205,8 +205,7 @@ class Bot(LoggingClass):
         Parameters
         ---------
         plugins : Optional[list(:class:`disco.bot.plugin.Plugin`)]
-            Any plugins to load after creating the new bot instance
-
+            Any plugins to load after creating the new bot instance.
         """
         from disco.cli import disco_main
         inst = cls(disco_main())
@@ -284,12 +283,12 @@ class Bot(LoggingClass):
         Parameters
         ---------
         msg : :class:`disco.types.message.Message`
-            The message object to parse and find matching commands for
+            The message object to parse and find matching commands for.
 
         Yields
         -------
         tuple(:class:`disco.bot.command.Command`, `re.MatchObject`)
-            All commands the message triggers
+            All commands the message triggers.
         """
         content = msg.content
 
@@ -382,7 +381,7 @@ class Bot(LoggingClass):
         Returns
         -------
         bool
-            whether any commands where successfully triggered by the message
+            Whether any commands where successfully triggered by the message.
         """
         commands = list(self.get_commands_for_message(
             self.config.commands_require_mention,
@@ -473,7 +472,7 @@ class Bot(LoggingClass):
             Plugin class to unload and remove.
         """
         if cls.__name__ not in self.plugins:
-            raise Exception('Cannot remove non-existant plugin: {}'.format(cls.__name__))
+            raise Exception('Cannot remove non-existent plugin: {}'.format(cls.__name__))
 
         ctx = {}
         self.plugins[cls.__name__].unload(ctx)

--- a/disco/bot/bot.py
+++ b/disco/bot/bot.py
@@ -249,7 +249,7 @@ class Bot(LoggingClass):
                 else:
                     possible[current] = group
 
-        # Now, we want to compute the actual shortest abbreivation out of the
+        # Now, we want to compute the actual shortest abbreviation out of the
         #  possible ones
         result = {}
         for abbrev, group in six.iteritems(possible):

--- a/disco/bot/command.py
+++ b/disco/bot/command.py
@@ -35,7 +35,7 @@ class CommandEvent(object):
     message information).
 
     Attributes
-    ---------
+    ----------
     command : :class:`Command`
         The command this event was created for (aka the triggered command).
     msg : :class:`disco.types.message.Message`
@@ -43,9 +43,9 @@ class CommandEvent(object):
     match : :class:`re.MatchObject`
         The regex match object for the command.
     name : str
-        The command name (or alias) which was triggered by the command
+        The command name (or alias) which was triggered by the command.
     args : list(str)
-        Arguments passed to the command
+        Arguments passed to the command.
     """
 
     def __init__(self, command, msg, match):
@@ -276,7 +276,7 @@ class Command(object):
         Returns
         -------
         bool
-            Whether this command was successful
+            Whether this command was successful.
         """
         parsed_kwargs = {}
 

--- a/disco/bot/parser.py
+++ b/disco/bot/parser.py
@@ -226,6 +226,6 @@ class ArgumentSet(object):
     @property
     def required_length(self):
         """
-        The number of required arguments to compile this set/specificaiton.
+        The number of required arguments to compile this set/specification.
         """
         return sum(i.true_count for i in self.args if i.required)

--- a/disco/bot/plugin.py
+++ b/disco/bot/plugin.py
@@ -436,8 +436,8 @@ class Plugin(LoggingClass, PluginDeco):
         Registers a function to be called repeatedly, waiting for an interval
         duration.
 
-        Args
-        ----
+        Parameters
+        ----------
         func : function
             The function to be registered.
         interval : int
@@ -447,8 +447,8 @@ class Plugin(LoggingClass, PluginDeco):
         init : bool
             Whether to run this schedule once immediately, or wait for the first
             scheduled iteration.
-        kwargs: dict
-            kwargs which will be passed to executed `func`
+        kwargs : dict
+            kwargs which will be passed to executed `func`.
         """
         if kwargs is None:
             kwargs = {}

--- a/disco/cli.py
+++ b/disco/cli.py
@@ -16,8 +16,8 @@ monkey.patch_all()
 parser = argparse.ArgumentParser()
 
 # Command line specific arguments
-parser.add_argument('--run-bot', help='run a disco bot on this client', action='store_true', default=False)
-parser.add_argument('--plugin', help='load plugins into the bot', nargs='*', default=[])
+parser.add_argument('--run-bot', help='Run a disco bot on this client', action='store_true', default=False)
+parser.add_argument('--plugin', help='Load plugins into the bot', nargs='*', default=[])
 parser.add_argument('--config', help='Configuration file', default=None)
 parser.add_argument('--shard-auto', help='Automatically run all shards', action='store_true', default=False)
 
@@ -29,7 +29,7 @@ parser.add_argument('--max-reconnects', help='Maximum reconnect attempts', defau
 parser.add_argument('--log-level', help='log level', default=None)
 parser.add_argument('--manhole', action='store_true', help='Enable the manhole', default=None)
 parser.add_argument('--manhole-bind', help='host:port for the manhole to bind too', default=None)
-parser.add_argument('--encoder', help='encoder for gateway data', default=None)
+parser.add_argument('--encoder', help='Encoder for gateway data', default=None)
 
 
 # Mapping of argument names to configuration overrides
@@ -53,7 +53,7 @@ def disco_main(run=False):
     Returns
     -------
     :class:`Client`
-        A new Client from the provided command line arguments
+        A new Client from the provided command line arguments.
     """
     from disco.client import Client, ClientConfig
     from disco.bot import Bot, BotConfig

--- a/disco/client.py
+++ b/disco/client.py
@@ -29,12 +29,12 @@ class ClientConfig(Config):
         Whether to enable subscription events (e.g. presence and typing).
     max_reconnects : int
         The maximum number of connection retries to make before giving up (0 = never give up).
-    log_level: str
+    log_level : str
         The logging level to use.
     manhole_enable : bool
         Whether to enable the manhole (e.g. console backdoor server) utility.
     manhole_bind : tuple(str, int)
-        A (host, port) combination which the manhole server will bind to (if its
+        A (host, port) combination which the manhole server will bind to (if it's
         enabled using :attr:`manhole_enable`).
     encoder : str
         The type of encoding to use for encoding/decoding data from websockets,
@@ -114,12 +114,12 @@ class Client(LoggingClass):
         """
         Updates the current clients presence.
 
-        Params
-        ------
+        Parameters
+        ----------
         status : `user.Status`
             The clients current status.
         game : `user.Game`
-            If passed, the game object to set for the users presence.
+            If passed, the game object to set for the user's presence.
         afk : bool
             Whether the client is currently afk.
         since : float

--- a/disco/gateway/events.py
+++ b/disco/gateway/events.py
@@ -133,7 +133,7 @@ class Ready(GatewayEvent):
     session_id : str
         The session ID.
     user : :class:`disco.types.user.User`
-        The user object for the authed account.
+        The user object for the authenticated account.
     guilds : list[:class:`disco.types.guild.Guild`
         All guilds this account is a member of. These are shallow guild objects.
     private_channels list[:class:`disco.types.channel.Channel`]
@@ -256,7 +256,7 @@ class ChannelPinsUpdate(GatewayEvent):
     ----------
     channel_id : snowflake
         ID of the channel where pins where updated.
-    last_pin_timestap : datetime
+    last_pin_timestamp : datetime
         The time the last message was pinned.
     """
     channel_id = Field(snowflake)

--- a/disco/gateway/events.py
+++ b/disco/gateway/events.py
@@ -127,7 +127,7 @@ class Ready(GatewayEvent):
     for bootstrapping the client's states.
 
     Attributes
-    -----
+    ----------
     version : int
         The gateway version.
     session_id : str
@@ -158,9 +158,9 @@ class GuildCreate(GatewayEvent):
     Sent when a guild is joined, or becomes available.
 
     Attributes
-    -----
+    ----------
     guild : :class:`disco.types.guild.Guild`
-        The guild being created (e.g. joined)
+        The guild being created (e.g. joined).
     unavailable : bool
         If false, this guild is coming online from a previously unavailable state,
         and if UNSET, this is a normal guild join event.
@@ -182,7 +182,7 @@ class GuildUpdate(GatewayEvent):
     Sent when a guild is updated.
 
     Attributes
-    -----
+    ----------
     guild : :class:`disco.types.guild.Guild`
         The updated guild object.
     """
@@ -193,7 +193,7 @@ class GuildDelete(GatewayEvent):
     Sent when a guild is deleted, left, or becomes unavailable.
 
     Attributes
-    -----
+    ----------
     id : snowflake
         The ID of the guild being deleted.
     unavailable : bool
@@ -217,7 +217,7 @@ class ChannelCreate(GatewayEvent):
     Sent when a channel is created.
 
     Attributes
-    -----
+    ----------
     channel : :class:`disco.types.channel.Channel`
         The channel which was created.
     """
@@ -229,7 +229,7 @@ class ChannelUpdate(ChannelCreate):
     Sent when a channel is updated.
 
     Attributes
-    -----
+    ----------
     channel : :class:`disco.types.channel.Channel`
         The channel which was updated.
     """
@@ -242,7 +242,7 @@ class ChannelDelete(ChannelCreate):
     Sent when a channel is deleted.
 
     Attributes
-    -----
+    ----------
     channel : :class:`disco.types.channel.Channel`
         The channel being deleted.
     """
@@ -253,7 +253,7 @@ class ChannelPinsUpdate(GatewayEvent):
     Sent when a channel's pins are updated.
 
     Attributes
-    -----
+    ----------
     channel_id : snowflake
         ID of the channel where pins where updated.
     last_pin_timestap : datetime
@@ -269,7 +269,7 @@ class GuildBanAdd(GatewayEvent):
     Sent when a user is banned from a guild.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild the user is being banned from.
     user : :class:`disco.types.user.User`
@@ -289,7 +289,7 @@ class GuildBanRemove(GuildBanAdd):
     Sent when a user is unbanned from a guild.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild the user is being unbanned from.
     user : :class:`disco.types.user.User`
@@ -306,11 +306,11 @@ class GuildEmojisUpdate(GatewayEvent):
     Sent when a guild's emojis are updated.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild the emojis are being updated in.
     emojis : list[:class:`disco.types.guild.Emoji`]
-        The new set of emojis for the guild
+        The new set of emojis for the guild.
     """
     guild_id = Field(snowflake)
     emojis = ListField(GuildEmoji)
@@ -321,7 +321,7 @@ class GuildIntegrationsUpdate(GatewayEvent):
     Sent when a guild's integrations are updated.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild integrations where updated in.
     """
@@ -333,7 +333,7 @@ class GuildMembersChunk(GatewayEvent):
     Sent in response to a member's chunk request.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild this member chunk is for.
     members : list[:class:`disco.types.guild.GuildMember`]
@@ -353,7 +353,7 @@ class GuildMemberAdd(GatewayEvent):
     Sent when a user joins a guild.
 
     Attributes
-    -----
+    ----------
     member : :class:`disco.types.guild.GuildMember`
         The member that has joined the guild.
     """
@@ -365,7 +365,7 @@ class GuildMemberRemove(GatewayEvent):
     Sent when a user leaves a guild (via leaving, kicking, or banning).
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild the member left from.
     user : :class:`disco.types.user.User`
@@ -385,7 +385,7 @@ class GuildMemberUpdate(GatewayEvent):
     Sent when a guilds member is updated.
 
     Attributes
-    -----
+    ----------
     member : :class:`disco.types.guild.GuildMember`
         The member being updated
     """
@@ -398,7 +398,7 @@ class GuildRoleCreate(GatewayEvent):
     Sent when a role is created.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild where the role was created.
     role : :class:`disco.types.guild.Role`
@@ -417,7 +417,7 @@ class GuildRoleUpdate(GuildRoleCreate):
     Sent when a role is updated.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild where the role was created.
     role : :class:`disco.types.guild.Role`
@@ -434,7 +434,7 @@ class GuildRoleDelete(GatewayEvent):
     Sent when a role is deleted.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild where the role is being deleted.
     role_id : snowflake
@@ -454,7 +454,7 @@ class MessageCreate(GatewayEvent):
     Sent when a message is created.
 
     Attributes
-    -----
+    ----------
     message : :class:`disco.types.message.Message`
         The message being created.
     guild_id : snowflake
@@ -469,7 +469,7 @@ class MessageUpdate(MessageCreate):
     Sent when a message is updated/edited.
 
     Attributes
-    -----
+    ----------
     message : :class:`disco.types.message.Message`
         The message being updated.
     guild_id : snowflake
@@ -483,7 +483,7 @@ class MessageDelete(GatewayEvent):
     Sent when a message is deleted.
 
     Attributes
-    -----
+    ----------
     id : snowflake
         The ID of message being deleted.
     channel_id : snowflake
@@ -509,7 +509,7 @@ class MessageDeleteBulk(GatewayEvent):
     Sent when multiple messages are deleted from a channel.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The guild the messages are being deleted in.
     channel_id : snowflake
@@ -536,7 +536,7 @@ class PresenceUpdate(GatewayEvent):
     Sent when a user's presence is updated.
 
     Attributes
-    -----
+    ----------
     presence : :class:`disco.types.user.Presence`
         The updated presence object.
     guild_id : snowflake
@@ -557,7 +557,7 @@ class TypingStart(GatewayEvent):
     Sent when a user begins typing in a channel.
 
     Attributes
-    -----
+    ----------
     guild_id : snowflake
         The ID of the guild where the user is typing.
     channel_id : snowflake
@@ -579,7 +579,7 @@ class VoiceStateUpdate(GatewayEvent):
     Sent when a users voice state changes.
 
     Attributes
-    -----
+    ----------
     state : :class:`disco.models.voice.VoiceState`
         The voice state which was updated.
     """
@@ -590,7 +590,7 @@ class VoiceServerUpdate(GatewayEvent):
     Sent when a voice server is updated.
 
     Attributes
-    -----
+    ----------
     token : str
         The token for the voice server.
     endpoint : str
@@ -608,7 +608,7 @@ class WebhooksUpdate(GatewayEvent):
     Sent when a channels webhooks are updated.
 
     Attributes
-    -----
+    ----------
     channel_id : snowflake
         The channel ID this webhooks update is for.
     guild_id : snowflake

--- a/disco/state.py
+++ b/disco/state.py
@@ -19,11 +19,11 @@ class StackMessage(namedtuple('StackMessage', ['id', 'channel_id', 'author_id'])
     Attributes
     ---------
     id : snowflake
-        the id of the message
+        The id of the message.
     channel_id : snowflake
-        the id of the channel this message was sent in
+        The id of the channel this message was sent in.
     author_id : snowflake
-        the id of the author of this message
+        The id of the author of this message.
     """
 
 
@@ -40,8 +40,8 @@ class StateConfig(Config):
 
         Message tracking is implemented using a deque and a namedtuple, meaning
         it should generally not have a high impact on memory, however users who
-        find they do not need and may be experiencing memory pressure can disable
-        this feature entirely using this attribute.
+        find that they do not need and may be experiencing memory pressure can
+        disable this feature entirely using this attribute.
     track_messages_size : int
         The size of the messages deque for each channel. This value can be used
         to calculate the total number of possible `StackMessage` objects kept in
@@ -50,7 +50,7 @@ class StateConfig(Config):
     sync_guild_members : bool
         If true, guilds will be automatically synced when they are initially loaded
         or joined. Generally this setting is OK for smaller bots, however bots in over
-        50 guilds will notice this operation can take a while to complete and may want
+        50 guilds will notice this operation can take a while to complete, and may want
         to batch requests using the underlying `GatewayClient.request_guild_members`
         interface.
     """
@@ -69,27 +69,27 @@ class State(object):
     Attributes
     ----------
     EVENTS : list(str)
-        A list of all events the State object binds to
+        A list of all events the State object binds to.
     client : `disco.client.Client`
-        The Client instance this state is attached to
+        The Client instance this state is attached to.
     config : `StateConfig`
-        The configuration for this state instance
+        The configuration for this state instance.
     me : `User`
-        The currently logged in user
+        The currently logged in user.
     dms : dict(snowflake, `Channel`)
-        Mapping of all known DM Channels
+        Mapping of all known DM Channels.
     guilds : dict(snowflake, `Guild`)
-        Mapping of all known/loaded Guilds
+        Mapping of all known/loaded Guilds.
     channels : dict(snowflake, `Channel`)
-        Weak mapping of all known/loaded Channels
+        Weak mapping of all known/loaded Channels.
     users : dict(snowflake, `User`)
-        Weak mapping of all known/loaded Users
+        Weak mapping of all known/loaded Users.
     voice_clients : dict(str, 'VoiceClient')
-        Weak mapping of all known voice clients
+        Weak mapping of all known voice clients.
     voice_states : dict(str, `VoiceState`)
-        Weak mapping of all known/active Voice States
+        Weak mapping of all known/active Voice States.
     messages : Optional[dict(snowflake, deque)]
-        Mapping of channel ids to deques containing `StackMessage` objects
+        Mapping of channel ids to deques containing `StackMessage` objects.
     """
     EVENTS = [
         'Ready', 'GuildCreate', 'GuildUpdate', 'GuildDelete', 'GuildMemberAdd', 'GuildMemberRemove',

--- a/disco/types/base.py
+++ b/disco/types/base.py
@@ -220,7 +220,7 @@ def datetime(data):
         except (ValueError, TypeError):
             continue
 
-    raise ValueError('Failed to conver `{}` to datetime'.format(data))
+    raise ValueError('Failed to convert `{}` to datetime'.format(data))
 
 
 def text(obj):

--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -43,13 +43,13 @@ class PermissionOverwrite(ChannelSubType):
     Attributes
     ----------
     id : snowflake
-        The overwrite ID
+        The overwrite ID.
     type : :const:`disco.types.channel.PermissionsOverwriteType`
-        The overwrite type
+        The overwrite type.
     allow : :class:`disco.types.permissions.PermissionValue`
-        All allowed permissions
+        All allowed permissions.
     deny : :class:`disco.types.permissions.PermissionValue`
-        All denied permissions
+        All denied permissions.
     """
     id = Field(snowflake)
     type = Field(enum(PermissionOverwriteType))
@@ -265,7 +265,7 @@ class Channel(SlottedModel, Permissible):
         Returns
         -------
         `Message`
-            The fetched message
+            The fetched message.
         """
         return self.client.api.channels_messages_get(self.id, to_snowflake(message))
 
@@ -304,8 +304,8 @@ class Channel(SlottedModel, Permissible):
         """
         Pins the given message to the channel.
 
-        Params
-        ------
+        Parameters
+        ----------
         message : `Message`|snowflake
             The message or message ID to pin.
         """
@@ -315,8 +315,8 @@ class Channel(SlottedModel, Permissible):
         """
         Unpins the given message from the channel.
 
-        Params
-        ------
+        Parameters
+        ----------
         message : `Message`|snowflake
             The message or message ID to pin.
         """
@@ -373,8 +373,8 @@ class Channel(SlottedModel, Permissible):
         """
         Deletes a single message from this channel.
 
-        Args
-        ----
+        Parameters
+        ----------
         message : snowflake|`Message`
             The message to delete.
         """
@@ -386,8 +386,8 @@ class Channel(SlottedModel, Permissible):
         Deletes a set of messages using the correct API route based on the number
         of messages passed.
 
-        Args
-        ----
+        Parameters
+        ----------
         messages : list(snowflake|`Message`)
             List of messages (or message ids) to delete. All messages must originate
             from this channel.

--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -112,7 +112,7 @@ class Channel(SlottedModel, Permissible):
         The channel's bitrate.
     user_limit : int
         The channel's user limit.
-    recipients: list(:class:`disco.types.user.User`)
+    recipients : list(:class:`disco.types.user.User`)
         Members of this channel (if this is a DM channel).
     type : :const:`ChannelType`
         The type of this channel.

--- a/disco/types/guild.py
+++ b/disco/types/guild.py
@@ -199,8 +199,8 @@ class GuildMember(SlottedModel):
         """
         Bans the member from the guild.
 
-        Args
-        ----
+        Parameters
+        ----------
         delete_message_days : int
             The number of days to retroactively delete messages for.
         """
@@ -216,8 +216,8 @@ class GuildMember(SlottedModel):
         """
         Sets the member's nickname (or clears it if None).
 
-        Args
-        ----
+        Parameters
+        ----------
         nickname : Optional[str]
             The nickname (or none to reset) to set.
         """

--- a/disco/types/guild.py
+++ b/disco/types/guild.py
@@ -158,7 +158,7 @@ class GuildMember(SlottedModel):
     roles : list(snowflake)
         Roles this member is part of.
     premium_since : datetime
-        When this user set their nitro boost to this server.
+        When this user set their Nitro boost to this server.
     """
     user = Field(User)
     guild_id = Field(snowflake)
@@ -316,7 +316,7 @@ class Guild(SlottedModel, Permissible):
     premium_tier : int
         Guild's premium tier.
     premium_subscription_count: int
-        The amount of users using their nitro boost on this guild.
+        The amount of users using their Nitro boost on this guild.
     """
     id = Field(snowflake)
     owner_id = Field(snowflake)

--- a/disco/types/guild.py
+++ b/disco/types/guild.py
@@ -315,7 +315,7 @@ class Guild(SlottedModel, Permissible):
         All of the guild's voice states.
     premium_tier : int
         Guild's premium tier.
-    premium_subscription_count: int
+    premium_subscription_count : int
         The amount of users using their Nitro boost on this guild.
     """
     id = Field(snowflake)

--- a/disco/types/message.py
+++ b/disco/types/message.py
@@ -482,8 +482,8 @@ class Message(SlottedModel):
         """
         Edit this message.
 
-        Args
-        ----
+        Parameters
+        ----------
         content : str
             The new edited contents of the message.
 
@@ -621,8 +621,8 @@ class Message(SlottedModel):
         """
         Replaces user and role mentions with the result of a given lambda/function.
 
-        Args
-        ----
+        Parameters
+        ----------
         user_replace : function
             A function taking a single argument, the user object mentioned, and
             returning a valid string.

--- a/disco/util/emitter.py
+++ b/disco/util/emitter.py
@@ -16,12 +16,12 @@ class Priority(object):
     #  with the one difference being it executes after all the BEFORE listeners.
     AFTER = 2
 
-    # SEQUENTIAL guarentees that all events your handler recieves will be ordered
+    # SEQUENTIAL guarantees that all events your handler receives will be ordered
     #  when looked at in isolation. SEQUENTIAL handlers will not block other handlers,
     #  but do use a queue internally and thus can fall behind.
     SEQUENTIAL = 3
 
-    # NONE provides no guarentees around the ordering or execution of events, sans
+    # NONE provides no guarantees around the ordering or execution of events, sans
     #  that BEFORE handlers will always complete before any NONE handlers are called.
     NONE = 4
 

--- a/disco/util/functional.py
+++ b/disco/util/functional.py
@@ -7,8 +7,8 @@ def take(seq, count):
     """
     Take count many elements from a sequence or generator.
 
-    Args
-    ----
+    Parameters
+    ----------
     seq : sequence or generator
         The sequence to take elements from.
     count : int

--- a/disco/util/functional.py
+++ b/disco/util/functional.py
@@ -25,8 +25,8 @@ def chunks(obj, size):
     """
     Splits a list into sized chunks.
 
-    Args
-    ----
+    Parameters
+    ----------
     obj : list
         List to split up.
     size : int

--- a/disco/util/logging.py
+++ b/disco/util/logging.py
@@ -21,7 +21,7 @@ def setup_logging(**kwargs):
     # Pass through our basic configuration
     logging.basicConfig(**kwargs)
 
-    # Override some noisey loggers
+    # Override some noisy loggers
     for logger, level in LEVEL_OVERRIDES.items():
         logging.getLogger(logger).setLevel(level)
 

--- a/disco/util/snowflake.py
+++ b/disco/util/snowflake.py
@@ -41,7 +41,7 @@ def to_snowflake(i):
     elif hasattr(i, 'id'):
         return i.id
 
-    raise Exception('{} ({}) is not convertable to a snowflake'.format(type(i), i))
+    raise Exception('{} ({}) is not convertible to a snowflake'.format(type(i), i))
 
 
 def calculate_shard(shard_count, guild_id):

--- a/disco/voice.py
+++ b/disco/voice.py
@@ -159,7 +159,7 @@ class VoiceConnection(object):
 
     def _event_reader(self, fd):
         if not make_nonblocking(fd):
-            raise Exception('failed to make event pipe nonblocking')
+            raise Exception('failed to make event pipe non-blocking')
 
         buff = ""
         while True:

--- a/docs/bot_tutorial/building_block_commands.md
+++ b/docs/bot_tutorial/building_block_commands.md
@@ -6,7 +6,7 @@ In the case of these examples, when you send `!help` or `!info` the bot will rep
 
 ## Basic commands
 
-Creating commands in Disco is really easy because of the [Plugins](https://b1naryth1ef.github.io/disco/bot_tutorial/building_block_plugins.html) that are a core fundamential of Disco. For more info on them, read back in the [Plugins](https://b1naryth1ef.github.io/disco/bot_tutorial/building_block_plugins.html) section of this tutorial. Creating a basic command is done as follows:
+Creating commands in Disco is really easy because of the [Plugins](https://b1naryth1ef.github.io/disco/bot_tutorial/building_block_plugins.html) that are a core fundamental of Disco. For more info on them, read back in the [Plugins](https://b1naryth1ef.github.io/disco/bot_tutorial/building_block_plugins.html) section of this tutorial. Creating a basic command is done as follows:
 First, create a Plugin class:
 ```py
 class myPlugin(Plugin):
@@ -48,7 +48,7 @@ Here, we added multiple arguments to our command. Namely, number a and number b,
 Lets create a tag system, that can either store a tag if you'd use it like this: `!tag name value` or retrieve a tag if you'd use it like this: `!tag name`
 
 We'll need 2 arguments. A name argument that's required, and an optional value argument. Inside the command we'll check if a `value` is provided. If there is, we'll store the tag. Otherwise, we'll try to retrieve the previously set value for that tag and return it.
-For the sake of this example, we'll asume that the `tags` dict gets stored somewhere so it doesn't get removed after a restart.
+For the sake of this example, we'll assume that the `tags` dict gets stored somewhere so it doesn't get removed after a restart.
 ```py
 tags = {}
 

--- a/docs/bot_tutorial/building_block_listeners.md
+++ b/docs/bot_tutorial/building_block_listeners.md
@@ -12,7 +12,7 @@ def on_message_create(self, event):
     self.log.debug('Got message: %s', event.message)
 ```
 
-Ok, but what if we want to make a listener which welcomes new users to our server? Well thats also easy:
+Ok, but what if we want to make a listener which welcomes new users to our server? Well that's also easy:
 
 ```py
 @Plugin.listen('GuildMemberAdd')

--- a/docs/bot_tutorial/message_embeds.md
+++ b/docs/bot_tutorial/message_embeds.md
@@ -46,7 +46,7 @@ embed.set_footer(text='Disco Message Embeds tutorial')
 embed.color = '10038562' #This can be any color, but I chose a nice dark red tint
 ```
 
-Once your embed is finshed, you can send it using the `channel.send_message()` message or the `event.msg.reply()` function.
+Once your embed is finished, you can send it using the `channel.send_message()` message or the `event.msg.reply()` function.
 With `channel.send_message()`:
 ```py
 self.state.channels.get(<ChannelID>).send_message('[optional text]', embed=embed)


### PR DESCRIPTION
This PR is mostly full of corrections for grammatical errors, typos, and consistency, based off of the design in [client.py](https://github.com/b1naryth1ef/disco/blob/master/disco/client.py). Most of the edits done here are for docstrings, so that they are formatted correctly - once again, according to the above file. The only question I have is of the docstring found [here](https://github.com/b1naryth1ef/disco/blob/master/disco/bot/plugin.py#L352), since `desc` is not explicitly written in the parameters or within the function. 

Just to let you know, I will recheck the library within the next few days in case I have made a mistake, or if there are a few extra bits that haven't yet been changed. You are free to point out mistakes in my PR.

The main changes are:
- Adding periods to the end of the sentences.
- Changing `Params`/`Args` -> `Parameters`.
- Changing spacing. `arg: type` -> `arg : type`
- Adding apostrophes. `its expected the ...` -> `it's expected the ...`