### PR TITLE
Fixes to permission calculations

### DIFF
--- a/disco/types/channel.py
+++ b/disco/types/channel.py
@@ -168,16 +168,11 @@ class Channel(SlottedModel, Permissible):
             base -= everyone.deny
             base += everyone.allow
 
-        denies = 0
-        allows = 0
         for role_id in member.roles:
             overwrite = self.overwrites.get(role_id)
             if overwrite:
-                denies |= overwrite.deny
-                allows |= overwrite.allow
-
-        base -= denies
-        base += allows
+                base -= overwrite.deny
+                base += overwrite.allow
 
         ow_member = self.overwrites.get(member.user.id)
         if ow_member:

--- a/disco/types/permissions.py
+++ b/disco/types/permissions.py
@@ -66,7 +66,7 @@ class PermissionValue(object):
         if isinstance(other, PermissionValue):
             self.value &= ~other.value
         elif isinstance(other, int):
-            self.value &= other
+            self.value &= ~other
         elif isinstance(other, EnumAttr):
             setattr(self, other.name, False)
         else:


### PR DESCRIPTION
This patch seems to fix some permissions calculation issues, from https://github.com/b1naryth1ef/disco/issues/98#issuecomment-462641470

- When I have a permission that is TRUE for the guild and NEUTRAL for the channel, `channel.get_permissions()` returns False for any UID and permission (even when I'm the server owner!).
- When I have a permission that is TRUE for the guild and FALSE for the channel, disco hits a TypeError when calculating permissions:

```
2019-02-11 22:57:18,555 [INFO] (discord) bursting guild 497939890063802369/OVD-NET
Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run
  File "/home/pylink/.local/lib/python3.5/site-packages/holster/emitter.py", line 72, in __call__
    return self.callback(*args, **kwargs)
  File "/home/pylink/.local/lib/python3.5/site-packages/disco_py-0.0.13rc2-py3.5.egg/disco/bot/plugin.py", line 335, in dispatch
    result = func(event, *args, **kwargs)
  File "/home/pylink/pylink-discord/protocols/discord.py", line 169, in on_server_connect
    self._burst_guild(event.guild)
  File "/home/pylink/pylink-discord/protocols/discord.py", line 73, in _burst_guild
    self._burst_new_client(guild, member, pylink_netobj)
  File "/home/pylink/pylink-discord/protocols/discord.py", line 130, in _burst_new_client
    channel_permissions = channel.get_permissions(member)
  File "/home/pylink/.local/lib/python3.5/site-packages/disco_py-0.0.13rc2-py3.5.egg/disco/types/channel.py", line 176, in get_permissions
    denies |= overwrite.deny
TypeError: unsupported operand type(s) for |=: 'int' and 'PermissionValue'
2019-02-12T06:57:18Z <Greenlet "Greenlet-0" at 0x7f8e55a55e48: <holster.emitter.EmitterSubscription object at 0x7f8e55a34240>(<disco.gateway.events.GuildCreate object at 0x7f8e)> failed with TypeError
```