### PR TITLE
Local Fixes & Client UserUpdate Gateway Event

### DIFF
--- a/disco/gateway/events.py
+++ b/disco/gateway/events.py
@@ -714,3 +714,14 @@ class MessageReactionRemoveAll(GatewayEvent):
     @property
     def guild(self):
         return self.channel.guild
+
+@wraps_model(User)
+class UserUpdate(GatewayEvent):
+    """
+    Sent when the client user is updated.
+
+    Attributes
+    -----
+    user : :class:`disco.types.user.User`
+        The updated user object.
+    """

--- a/disco/gateway/events.py
+++ b/disco/gateway/events.py
@@ -715,6 +715,7 @@ class MessageReactionRemoveAll(GatewayEvent):
     def guild(self):
         return self.channel.guild
 
+
 @wraps_model(User)
 class UserUpdate(GatewayEvent):
     """

--- a/disco/state.py
+++ b/disco/state.py
@@ -154,7 +154,7 @@ class State(object):
             self.channels[dm.id] = dm
 
     def on_user_update(self, event):
-        self.me = event.user
+        self.me.inplace_update(event.user)
 
     def on_message_create(self, event):
         if self.config.track_messages:

--- a/disco/state.py
+++ b/disco/state.py
@@ -153,6 +153,9 @@ class State(object):
             self.dms[dm.id] = dm
             self.channels[dm.id] = dm
 
+    def on_user_update(self, event):
+        self.me = event.user
+
     def on_message_create(self, event):
         if self.config.track_messages:
             self.messages[event.message.channel_id].append(

--- a/disco/types/guild.py
+++ b/disco/types/guild.py
@@ -338,9 +338,9 @@ class Guild(SlottedModel, Permissible):
     voice_states = AutoDictField(VoiceState, 'session_id')
     member_count = Field(int)
     premium_tier = Field(int)
-    premium_subscription_count = Field(int)
+    premium_subscription_count = Field(int, default=0)
     vanity_url_code = Field(text)
-    max_presences = Field(int)
+    max_presences = Field(int, default=5000)
     max_members = Field(int)
     description = Field(text)
 

--- a/disco/types/permissions.py
+++ b/disco/types/permissions.py
@@ -11,7 +11,7 @@ class Permissions(object):
     ADD_REACTIONS = 1 << 6
     VIEW_AUDIT_LOG = 1 << 7
     PRIORITY_SPEAKER = 1 << 8
-    READ_MESSAGES = 1 << 10
+    VIEW_CHANNEL = 1 << 10
     SEND_MESSAGES = 1 << 11
     SEND_TSS_MESSAGES = 1 << 12
     MANAGE_MESSAGES = 1 << 13


### PR DESCRIPTION
- Changed 'READ_MESSAGES' to 'VIEW_CHANNEL' to keep with Discord's API Docs
- Defaulted Guild.premium_subscription_count to 0 to stop error
- Guild.max_presences to 5,000 as Discord's API Suggest
- Added UserUpdate event for when the Client user is updated.