### PR TITLE
Support 'User (mention)' style mentions used by recent client updates

### DIFF
--- a/disco/bot/bot.py
+++ b/disco/bot/bot.py
@@ -312,6 +312,7 @@ class Bot(LoggingClass):
                         if member.nick:
                             content = content.replace(member.mention, '', 1)
                         content = content.replace(member.user.mention, '', 1)
+                        content = content.replace(member.user.mention_nickname, '', 1)
                 else:
                     content = content.replace(self.client.state.me.mention, '', 1)
             elif mention_everyone:

--- a/disco/bot/bot.py
+++ b/disco/bot/bot.py
@@ -308,9 +308,7 @@ class Bot(LoggingClass):
                 if msg.guild:
                     member = msg.guild.get_member(self.client.state.me)
                     if member:
-                        # If nickname is set, filter both the normal and nick mentions
-                        if member.nick:
-                            content = content.replace(member.mention, '', 1)
+                        # Filter both the normal and nick mentions
                         content = content.replace(member.user.mention, '', 1)
                         content = content.replace(member.user.mention_nickname, '', 1)
                 else:

--- a/disco/types/user.py
+++ b/disco/types/user.py
@@ -44,6 +44,10 @@ class User(SlottedModel, with_equality('id'), with_hash('id')):
     def mention(self):
         return '<@{}>'.format(self.id)
 
+    @property
+    def mention_nickname(self):
+        return '<@!{}>'.format(self.id)
+
     def open_dm(self):
         return self.client.api.users_me_dms_create(self.id)
 


### PR DESCRIPTION
With a recent update, discord clients have started using `<@!USER_ID>` style mentions. This is documented [here](https://discordapp.com/developers/docs/reference#message-formatting) - I don't know when it was added, but I do know recent versions suddenly started using it, causing my bot to stop responding to commands from any user who upgraded.

This hack isn't a solution to the core problem that mentions can now have two different formats, but it at least does make commands work again in the common case. I figured since I needed to patch it up, I should at least let you know of it.