### PR TITLE
migrate/deprecate discordapp.com => discord.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/disco-py.svg)](https://pypi.python.org/pypi/disco-py/)
 [![TravisCI](https://img.shields.io/travis/b1naryth1ef/disco.svg)](https://travis-ci.org/b1naryth1ef/disco/)
 
-Disco is an extensive and extendable Python 2.x/3.x library for the [Discord API](https://discordapp.com/developers/docs/intro). Disco boasts the following major features:
+Disco is an extensive and extendable Python 2.x/3.x library for the [Discord API](https://discord.com/developers/docs/intro). Disco boasts the following major features:
 
 - Expressive, functional interface that gets out of the way
 - Built for high-performance and efficiency

--- a/disco/api/http.py
+++ b/disco/api/http.py
@@ -189,7 +189,7 @@ class HTTPClient(LoggingClass):
     A simple HTTP client which wraps the requests library, adding support for
     Discords rate-limit headers, authorization, and request/response validation.
     """
-    BASE_URL = 'https://discord.com/api/v6'
+    BASE_URL = 'https://discord.com/api/v7'
     MAX_RETRIES = 5
 
     def __init__(self, token, after_request=None):

--- a/disco/api/http.py
+++ b/disco/api/http.py
@@ -189,7 +189,7 @@ class HTTPClient(LoggingClass):
     A simple HTTP client which wraps the requests library, adding support for
     Discords rate-limit headers, authorization, and request/response validation.
     """
-    BASE_URL = 'https://discordapp.com/api/v7'
+    BASE_URL = 'https://discord.com/api/v6'
     MAX_RETRIES = 5
 
     def __init__(self, token, after_request=None):

--- a/disco/voice/udp.py
+++ b/disco/voice/udp.py
@@ -1,13 +1,14 @@
 import struct
 import socket
 import gevent
+import warnings
 
 from collections import namedtuple
 
 try:
     import nacl.secret
 except ImportError:
-    print('WARNING: nacl is not installed, voice support is disabled')
+    warnings.warn('nacl is not installed, voice support is disabled')
 
 from holster.enum import Enum
 

--- a/docs/bot_tutorial/first_steps.md
+++ b/docs/bot_tutorial/first_steps.md
@@ -4,7 +4,7 @@ Disco provides a built-in set of tools for building and running Discord bots whi
 
 ## Creating a Bot
 
-The first step to creating bots is to actually register them on Discord itself. To do this, you'll need to be logged into your Discord account on the browser and then navigate to [My Apps](https://discordapp.com/developers/applications/me). Here you'll have the option to create a new application, and once created you can add a bot user (by clicking "Create a Bot User") to your application. Finally, you'll want to keep track of the bot user token which can be shown by clicking the "click to reveal" link next to the token field.
+The first step to creating bots is to actually register them on Discord itself. To do this, you'll need to be logged into your Discord account on the browser and then navigate to [My Apps](https://discord.com/developers/applications). Here you'll have the option to create a new application, and once created you can add a bot user (by clicking "Create a Bot User") to your application. Finally, you'll want to keep track of the bot user token which can be shown by clicking the "click to reveal" link next to the token field.
 
 Once you have a Discord bot account, you can then setup your workspace. For now we'll just need a folder (perhaps called `disco-tutorial`) with a few files in it:
 


### PR DESCRIPTION
- [x] replace discordapp.com with discord.com (ahead of on 2020-11-07 move. cdn.discordapp.com is remaining as-is though)
- [x] confirm that everything still works?
- fixes #180